### PR TITLE
Adding variable Ore capacity threshhold

### DIFF
--- a/implement/applications/eve-online/eve-online-mining-bot/src/Bot.elm
+++ b/implement/applications/eve-online/eve-online-mining-bot/src/Bot.elm
@@ -309,7 +309,7 @@ inSpaceWithOreHoldSelected context seeUndockingComplete inventoryWindowWithOreHo
 
                     Just fillPercent ->
                         if context.settings.oreHoldMaxPercent <= fillPercent then
-                            DescribeBranch ("The ore hold is over " ++ (context.settings.oreHoldMaxPercent |> String.fromInt) ++ "percent. Dock to station.")
+                            DescribeBranch ("The ore hold is over " ++ (context.settings.oreHoldMaxPercent |> String.fromInt) ++ "%. Dock to station.")
                                 (case context |> lastDockedStationNameFromInfoPanelFromMemoryOrSettings of
                                     Nothing ->
                                         DescribeBranch "At which station should I dock?. I was never docked in a station in this session." (EndDecisionPath Wait)
@@ -321,7 +321,7 @@ inSpaceWithOreHoldSelected context seeUndockingComplete inventoryWindowWithOreHo
                                 )
 
                         else
-                            DescribeBranch "The ore hold is not full enough yet. Get more ore."
+                            DescribeBranch ("The ore hold is not over  " ++ (context.settings.oreHoldMaxPercent |> String.fromInt) ++ "% yet. Get more ore.")
                                 (case context.parsedUserInterface.targets |> List.head of
                                     Nothing ->
                                         DescribeBranch "I see no locked target." (ensureIsAtMiningSiteAndTargetAsteroid context)

--- a/implement/applications/eve-online/eve-online-mining-bot/src/Bot.elm
+++ b/implement/applications/eve-online/eve-online-mining-bot/src/Bot.elm
@@ -78,7 +78,7 @@ parseBotSettingsNames =
       , \stationName -> Ok (\settings -> { settings | lastDockedStationNameFromInfoPanel = Just stationName })
       )
     , ( "ore-hold-max-percent"
-      , parseBotSettingInt (\threshold settings -> { settings | oreHoldMaxPercent = threshold })
+      , parseBotSettingInt (\percent settings -> { settings | oreHoldMaxPercent = percent })
       )
     ]
         |> Dict.fromList

--- a/implement/applications/eve-online/eve-online-mining-bot/src/Bot.elm
+++ b/implement/applications/eve-online/eve-online-mining-bot/src/Bot.elm
@@ -308,8 +308,8 @@ inSpaceWithOreHoldSelected context seeUndockingComplete inventoryWindowWithOreHo
                         DescribeBranch "I cannot see the ore hold capacity gauge." (EndDecisionPath Wait)
 
                     Just fillPercent ->
-                        if oreHoldMaxPercent <= fillPercent then
-                            DescribeBranch "The ore hold is over " ++ (oreHoldMaxPercent |> String.fromInt) ++ "percent. Dock to station."
+                        if context.settings.oreHoldMaxPercent <= fillPercent then
+                            DescribeBranch "The ore hold is over " ++ (context.settings.oreHoldMaxPercent |> String.fromInt) ++ "percent. Dock to station."
                                 (case context |> lastDockedStationNameFromInfoPanelFromMemoryOrSettings of
                                     Nothing ->
                                         DescribeBranch "At which station should I dock?. I was never docked in a station in this session." (EndDecisionPath Wait)

--- a/implement/applications/eve-online/eve-online-mining-bot/src/Bot.elm
+++ b/implement/applications/eve-online/eve-online-mining-bot/src/Bot.elm
@@ -309,7 +309,7 @@ inSpaceWithOreHoldSelected context seeUndockingComplete inventoryWindowWithOreHo
 
                     Just fillPercent ->
                         if context.settings.oreHoldMaxPercent <= fillPercent then
-                            DescribeBranch "The ore hold is over " ++ (context.settings.oreHoldMaxPercent |> String.fromInt) ++ "percent. Dock to station."
+                            DescribeBranch ("The ore hold is over " ++ (context.settings.oreHoldMaxPercent |> String.fromInt) ++ "percent. Dock to station.")
                                 (case context |> lastDockedStationNameFromInfoPanelFromMemoryOrSettings of
                                     Nothing ->
                                         DescribeBranch "At which station should I dock?. I was never docked in a station in this session." (EndDecisionPath Wait)

--- a/implement/applications/eve-online/eve-online-mining-bot/src/Bot.elm
+++ b/implement/applications/eve-online/eve-online-mining-bot/src/Bot.elm
@@ -54,6 +54,7 @@ defaultBotSettings =
     , miningModuleRange = 5000
     , botStepDelayMilliseconds = 2000
     , lastDockedStationNameFromInfoPanel = Nothing
+    , oreHoldMaxPercent = 99
     }
 
 
@@ -75,6 +76,9 @@ parseBotSettingsNames =
       )
     , ( "last-docked-station-name-from-info-panel"
       , \stationName -> Ok (\settings -> { settings | lastDockedStationNameFromInfoPanel = Just stationName })
+      )
+    , ( "ore-hold-max-percent"
+      , parseBotSettingInt (\threshold settings -> { settings | oreHoldMaxPercent = threshold })
       )
     ]
         |> Dict.fromList
@@ -303,8 +307,8 @@ inSpaceWithOreHoldSelected context seeUndockingComplete inventoryWindowWithOreHo
                         DescribeBranch "I cannot see the ore hold capacity gauge." (EndDecisionPath Wait)
 
                     Just fillPercent ->
-                        if 80 <= fillPercent then
-                            DescribeBranch "The ore hold is over 80 percent. Dock to station."
+                        if oreHoldMaxPercent <= fillPercent then
+                            DescribeBranch "The ore hold is over " ++ (oreHoldMaxPercent |> String.fromInt) ++ "percent. Dock to station."
                                 (case context |> lastDockedStationNameFromInfoPanelFromMemoryOrSettings of
                                     Nothing ->
                                         DescribeBranch "At which station should I dock?. I was never docked in a station in this session." (EndDecisionPath Wait)

--- a/implement/applications/eve-online/eve-online-mining-bot/src/Bot.elm
+++ b/implement/applications/eve-online/eve-online-mining-bot/src/Bot.elm
@@ -309,7 +309,7 @@ inSpaceWithOreHoldSelected context seeUndockingComplete inventoryWindowWithOreHo
 
                     Just fillPercent ->
                         if context.settings.oreHoldMaxPercent <= fillPercent then
-                            DescribeBranch ("The ore hold is over " ++ (context.settings.oreHoldMaxPercent |> String.fromInt) ++ "%. Dock to station.")
+                            DescribeBranch ("The ore hold is over" ++ (context.settings.oreHoldMaxPercent |> String.fromInt) ++ "%. Dock to station.")
                                 (case context |> lastDockedStationNameFromInfoPanelFromMemoryOrSettings of
                                     Nothing ->
                                         DescribeBranch "At which station should I dock?. I was never docked in a station in this session." (EndDecisionPath Wait)

--- a/implement/applications/eve-online/eve-online-mining-bot/src/Bot.elm
+++ b/implement/applications/eve-online/eve-online-mining-bot/src/Bot.elm
@@ -303,8 +303,8 @@ inSpaceWithOreHoldSelected context seeUndockingComplete inventoryWindowWithOreHo
                         DescribeBranch "I cannot see the ore hold capacity gauge." (EndDecisionPath Wait)
 
                     Just fillPercent ->
-                        if 99 <= fillPercent then
-                            DescribeBranch "The ore hold is full enough. Dock to station."
+                        if 80 <= fillPercent then
+                            DescribeBranch "The ore hold is over 80 percent. Dock to station."
                                 (case context |> lastDockedStationNameFromInfoPanelFromMemoryOrSettings of
                                     Nothing ->
                                         DescribeBranch "At which station should I dock?. I was never docked in a station in this session." (EndDecisionPath Wait)

--- a/implement/applications/eve-online/eve-online-mining-bot/src/Bot.elm
+++ b/implement/applications/eve-online/eve-online-mining-bot/src/Bot.elm
@@ -90,6 +90,7 @@ type alias BotSettings =
     , miningModuleRange : Int
     , botStepDelayMilliseconds : Int
     , lastDockedStationNameFromInfoPanel : Maybe String
+    , oreHoldMaxPercent : Int
     }
 
 


### PR DESCRIPTION
This gives an app-setting that lets you define what you want the threshold to be.  It keeps the default at the original 99%.

When I have a 7000 capacity in my Ore hold, and my ice miners cycle at 1500 each every two minutes, I don't want to waste two minutes every round trip for the last few percents to fill up.

