### PR TITLE
Updated mining for Eve version 19.11 released on 2021-12-07

### DIFF
--- a/explore/2020-12-07-explore-multi-instance-scenarios/eve-online-test-coordinate-input-focus/BotEngineApp.elm
+++ b/explore/2020-12-07-explore-multi-instance-scenarios/eve-online-test-coordinate-input-focus/BotEngineApp.elm
@@ -167,7 +167,7 @@ inventoryWindowWithOreHoldSelectedFromGameClient =
 
 inventoryWindowSelectedContainerIsOreHold : EveOnline.ParseUserInterface.InventoryWindow -> Bool
 inventoryWindowSelectedContainerIsOreHold =
-    .subCaptionLabelText >> Maybe.map (String.toLower >> String.contains "ore hold") >> Maybe.withDefault False
+    .subCaptionLabelText >> Maybe.map (String.toLower >> String.contains "mining hold") >> Maybe.withDefault False
 
 
 itemHangarFromInventoryWindow : EveOnline.ParseUserInterface.InventoryWindow -> Maybe UIElement

--- a/explore/2020-12-07-explore-multi-instance-scenarios/eve-online-test-coordinate-input-focus/EveOnline/ParseUserInterface.elm
+++ b/explore/2020-12-07-explore-multi-instance-scenarios/eve-online-test-coordinate-input-focus/EveOnline/ParseUserInterface.elm
@@ -1720,7 +1720,7 @@ parseInventoryWindow windowUiNode =
             rightContainerNode
                 |> Maybe.andThen
                     (listDescendantsWithDisplayRegion
-                        >> List.filter (\uiNode -> [ "ShipCargo", "ShipDroneBay", "ShipOreHold", "StationItems" ] |> List.member uiNode.uiNode.pythonObjectTypeName)
+                        >> List.filter (\uiNode -> [ "ShipCargo", "ShipDroneBay", "ShipGeneralMiningHold", "StationItems" ] |> List.member uiNode.uiNode.pythonObjectTypeName)
                         >> List.head
                     )
 

--- a/implement/applications/eve-online/eve-online-combat-anomaly-bot/EveOnline/ParseUserInterface.elm
+++ b/implement/applications/eve-online/eve-online-combat-anomaly-bot/EveOnline/ParseUserInterface.elm
@@ -1923,7 +1923,7 @@ parseInventoryWindow windowUiNode =
                     (listDescendantsWithDisplayRegion
                         >> List.filter
                             (\uiNode ->
-                                [ "ShipCargo", "ShipDroneBay", "ShipOreHold", "StationItems", "ShipFleetHangar", "StructureItemHangar" ]
+                                [ "ShipCargo", "ShipDroneBay", "ShipGeneralMiningHold", "StationItems", "ShipFleetHangar", "StructureItemHangar" ]
                                     |> List.member uiNode.uiNode.pythonObjectTypeName
                             )
                         >> List.head

--- a/implement/applications/eve-online/eve-online-mining-bot/Bot.elm
+++ b/implement/applications/eve-online/eve-online-mining-bot/Bot.elm
@@ -564,7 +564,7 @@ ensureOreHoldIsSelectedInInventoryWindow readingFromGameClient continueWithInven
                                     maybeOreHoldTreeEntry =
                                         activeShipTreeEntry.children
                                             |> List.map EveOnline.ParseUserInterface.unwrapInventoryWindowLeftTreeEntryChild
-                                            |> List.filter (.text >> String.toLower >> String.contains "ore hold")
+                                            |> List.filter (.text >> String.toLower >> String.contains "mining hold")
                                             |> List.head
                                 in
                                 case maybeOreHoldTreeEntry of
@@ -1135,7 +1135,7 @@ inventoryWindowWithOreHoldSelectedFromGameClient =
 
 inventoryWindowSelectedContainerIsOreHold : EveOnline.ParseUserInterface.InventoryWindow -> Bool
 inventoryWindowSelectedContainerIsOreHold =
-    .subCaptionLabelText >> Maybe.map (String.toLower >> String.contains "ore hold") >> Maybe.withDefault False
+    .subCaptionLabelText >> Maybe.map (String.toLower >> String.contains "mining hold") >> Maybe.withDefault False
 
 
 selectedContainerFirstItemFromInventoryWindow : EveOnline.ParseUserInterface.InventoryWindow -> Maybe UIElement

--- a/implement/applications/eve-online/eve-online-mining-bot/EveOnline/ParseUserInterface.elm
+++ b/implement/applications/eve-online/eve-online-mining-bot/EveOnline/ParseUserInterface.elm
@@ -1923,7 +1923,7 @@ parseInventoryWindow windowUiNode =
                     (listDescendantsWithDisplayRegion
                         >> List.filter
                             (\uiNode ->
-                                [ "ShipCargo", "ShipDroneBay", "ShipOreHold", "StationItems", "ShipFleetHangar", "StructureItemHangar" ]
+                                [ "ShipCargo", "ShipDroneBay", "ShipGeneralMiningHold", "StationItems", "ShipFleetHangar", "StructureItemHangar" ]
                                     |> List.member uiNode.uiNode.pythonObjectTypeName
                             )
                         >> List.head

--- a/implement/applications/eve-online/eve-online-sanderling-framework/src/EveOnline/ParseUserInterface.elm
+++ b/implement/applications/eve-online/eve-online-sanderling-framework/src/EveOnline/ParseUserInterface.elm
@@ -1923,7 +1923,7 @@ parseInventoryWindow windowUiNode =
                     (listDescendantsWithDisplayRegion
                         >> List.filter
                             (\uiNode ->
-                                [ "ShipCargo", "ShipDroneBay", "ShipOreHold", "StationItems", "ShipFleetHangar", "StructureItemHangar" ]
+                                [ "ShipCargo", "ShipDroneBay", "ShipGeneralMiningHold", "StationItems", "ShipFleetHangar", "StructureItemHangar" ]
                                     |> List.member uiNode.uiNode.pythonObjectTypeName
                             )
                         >> List.head

--- a/implement/applications/eve-online/eve-online-warp-to-0-autopilot/EveOnline/ParseUserInterface.elm
+++ b/implement/applications/eve-online/eve-online-warp-to-0-autopilot/EveOnline/ParseUserInterface.elm
@@ -1923,7 +1923,7 @@ parseInventoryWindow windowUiNode =
                     (listDescendantsWithDisplayRegion
                         >> List.filter
                             (\uiNode ->
-                                [ "ShipCargo", "ShipDroneBay", "ShipOreHold", "StationItems", "ShipFleetHangar", "StructureItemHangar" ]
+                                [ "ShipCargo", "ShipDroneBay", "ShipGeneralMiningHold", "StationItems", "ShipFleetHangar", "StructureItemHangar" ]
                                     |> List.member uiNode.uiNode.pythonObjectTypeName
                             )
                         >> List.head


### PR DESCRIPTION
Hello. The mining bot has been broken since update yesterday, it's unable to unload ore when docked and undocks with full ore hold instead. That is because UI tree has changed, both internal python name and on-screen ore hold label. The changes I propose fix the issue for me.